### PR TITLE
docs: expand README with dev and prod setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SoloPixelingBot
 
-SoloPixelingBot is a modular Discord bot designed for the Solo Pixeling community.  
+SoloPixelingBot is a modular Discord bot designed for the Solo Pixeling community.
 It automates server tasks such as welcome messages, giveaways, XP-based leveling, scheduled role pings, and bug reporting—all built on top of [discord.py](https://discordpy.readthedocs.io) with a Supabase backend.
 
 ---
@@ -63,6 +63,15 @@ tests/                   # Unit tests (pytest)
 
 ---
 
+## How It Works
+
+- Uses [discord.py](https://discordpy.readthedocs.io) with a cog-based architecture. Each module under `src/cogs/` contains a related set of slash commands and event listeners.
+- `src/bot.py` discovers and loads all cogs on startup, then syncs the slash commands to the target guild and globally.
+- `src/config.py` reads environment variables to decide whether the bot runs in development or production mode and to pull in guild/channel IDs and tokens.
+- Persistent data such as XP, giveaways, and reports is stored in Supabase through the helper classes under `src/data/`.
+
+---
+
 ## Requirements
 
 - Python **3.10+**
@@ -90,15 +99,35 @@ tests/                   # Unit tests (pytest)
    pip install -r requirements.txt  # or requirements-dev.txt for development
    ```
 
-3. **Set up a `.env` file** (example values):
+3. **Set up a `.env` file**
+
+   The bot reads configuration from environment variables. Create a `.env` file in the project root with values like the following:
+
+   **Development mode** (`ENVIRONMENT=dev`)
 
    ```env
-   ENVIRONMENT=prod                 # or "dev"
-   TOKEN=your_bot_token             # use TEST_TOKEN in dev mode
+   ENVIRONMENT=dev
+   TEST_TOKEN=your_dev_bot_token
+   TEST_GUILD_ID=123456789012345678
+   TEST_DEFAULT_WELCOME_CHANNEL_ID=123456789012345678
+   TEST_DEFAULT_LEVELUP_CHANNEL_ID=123456789012345678
+   TEST_BUG_REPORT_CHANNEL_ID=123456789012345678
+   ```
+
+   **Production mode** (`ENVIRONMENT=prod` or unset)
+
+   ```env
+   ENVIRONMENT=prod
+   TOKEN=your_prod_bot_token
    GUILD_ID=123456789012345678
    DEFAULT_WELCOME_CHANNEL_ID=123456789012345678
    DEFAULT_LEVELUP_CHANNEL_ID=123456789012345678
    BUG_REPORT_CHANNEL_ID=123456789012345678
+   ```
+
+   **Common settings**
+
+   ```env
    EXCLUDED_CHANNELS=111,222,333
    REPORT_GUILD_ID=987654321098765432
    SUPABASE_URL=https://project.supabase.co
@@ -114,6 +143,17 @@ python -m src.bot
 ```
 
 The bot auto-loads all cogs on startup, synchronizes slash commands, and begins processing events.
+
+---
+
+## Development vs Production Modes
+
+`config.py` checks the `ENVIRONMENT` variable to decide which credentials to load:
+
+- `ENVIRONMENT=dev` &rarr; uses the `TEST_` tokens and channel IDs and prints "⚙️ Running in Development mode." on startup.
+- `ENVIRONMENT=prod` or unset &rarr; uses the production variables and prints "🚀 Running in Production mode.".
+
+Ensure the corresponding token and IDs are present in the `.env` file before starting the bot.
 
 ---
 


### PR DESCRIPTION
## Summary
- document bot architecture and environment configuration
- explain development vs production modes and required `.env` variables

## Testing
- `bash run_checks.sh` *(fails: pylint: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899660d2544832f97cbd902eaebe846